### PR TITLE
Changed H2 to File mode.

### DIFF
--- a/infrastructure/src/main/resources/application.yml
+++ b/infrastructure/src/main/resources/application.yml
@@ -1,9 +1,13 @@
 spring:
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test
+    url: jdbc:h2:./test
     username: sa
     password:
+    initialization-mode: always
+  batch:
+    jdbc:
+      initialize-schema: always
 logging:
   level:
     jp:


### PR DESCRIPTION
## H2 をファイルモードで実施する設定

#### データの確認方法

バッチ実行後に、プロジェクト直下にできる test.mv.db を DBeaver などで確認。

![image](https://user-images.githubusercontent.com/10845156/182795174-5719e166-9da2-4515-aacf-bb0e082f4955.png)
![image](https://user-images.githubusercontent.com/10845156/182795383-12ec004a-ae62-4558-ac9c-32757101f6c7.png)

##### 変更したパラメータの参考

- [Spring BootでH2DBを組み込みモード（永続化あり）で利用する - てのひら](https://www.tenohira.xyz/tech/spring-h2db-setting/)

#### テーブルの説明

- BATCH_* のテーブル
  spring batch により、作成されるテーブル。JOB の実行状況を保存している。
- EMPLOYEE* のテーブル
  今回作成されたテーブル。EMPLOYEE が初期データ。EMPLOYEE_EXTRACT_EXECUTION に抽出したレコードが格納されている。
